### PR TITLE
Migrate deprecated set-output to GITHUB_OUTPUT env

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
     - id: run-script
       run: |
         result=$(base=${{ inputs.base-image }} image=${{ inputs.image }} ${{ github.action_path }}/docker.sh)
-        echo "::set-output name=result::${result}"
+        echo "result=${result}" >>$GITHUB_OUTPUT
       shell: bash
 
 branding:


### PR DESCRIPTION
Fixes #6 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/