### PR TITLE
handle_library_dockerhub_images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: Test
 on: [push]
 
 jobs:
-  test:
+  test1:
     name: Test-Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
       - name: Checkout Repository
@@ -21,3 +21,21 @@ jobs:
       - name: Check value
         run: echo "Needs updating"
         if: steps.test.outputs.needs-updating == 'true'
+  test2:
+    name: Test-Action
+    runs-on: ubuntu-22.04
+    continue-on-error: true
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Test Action
+        id: test
+        uses: ./
+        with:
+          base-image: nginx:1.21.0
+          image: library/nginx:1.21.0
+      - name: Get Test Output
+        run: echo "Workflow Docker Image ${{ steps.test.outputs.needs-updating }}"
+      - name: Check value
+        run: echo "Does not need updating"
+        if: steps.test.outputs.needs-updating == 'false'


### PR DESCRIPTION
Hi,

I needed some time to find out that for official docker images you need to add the prefix `library/`.
I think we could do this automatically detecting that docker is responding with an error and the provided image name does not start with `username/`.
This will probably save some time for the users of this github action :-)