### PR TITLE
[v1.2.0] Removes double quotes that is causing image names to be handled incorrectly

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -90,12 +90,12 @@ check_if_library() {
 IFS=: read base base_tag <<<$base
 IFS=: read image image_tag <<<$image
 
-check_if_library "$base"
+check_if_library $base
 base_repo=${result[0]}
 base_token=${result[1]}
 manifests_base=$(get_manifests $base_repo ${base_tag:-latest} $base_token)
 
-check_if_library "$image"
+check_if_library $image
 image_repo=${result[0]}
 image_token=${result[1]}
 manifests_image=$(get_manifests $image_repo ${image_tag:-latest} $image_token)


### PR DESCRIPTION
**On version 1.2.0**

Some images names can be interpolated wrongly on the `docker.sh` script.

Example (with debug):
```shell
base=library/postgres:12.0 image=hbontempo/postgres-hll:12.0-v2.14 platforms=linux/amd64 ./docker.sh
+ set -o nounset
+ set -o errexit
+ set -o pipefail
+ '[' 0 -eq 1 ']'
+ IFS=:
+ read base base_tag
+ IFS=:
+ read image image_tag
+ check_if_library 'library/postgres 12.0'
+ local 'IMAGE_PATTERN_WITH_USERNAME=^.+/.+$'
+ local 'repo=library/postgres 12.0'
+ local token
++ get_token 'library/postgres 12.0'
++ local 'repo=library/postgres 12.0'
++ local url
++ url='https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/postgres 12.0:pull'
++ curl -fsSL 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/postgres 12.0:pull'
++ jq -r .token
+ token=
```

The error appears to an unexpected the `base` is having some kind of bad shell expansion when using the double quotes here:
```bash
check_if_library "$base"
```

This PRs fixes this unexpected behaviour by simply removing the (unnecessary?) quotes. 