### PR TITLE
Add test for 386

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -122,6 +122,31 @@ jobs:
             exit 1
           fi
 
+  test386:
+    name: Test Update Needed on 386
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Test Action
+        id: test
+        uses: ./
+        with:
+          base-image: debian:stable-slim
+          image: lucacome/debian-386:13.0-slim
+          platforms: linux/386
+
+      - name: Get Test Output (needs-updating=${{ steps.test.outputs.needs-updating }})
+        run: |
+          echo "Images: ${{ steps.test.outputs.diff-images }}"
+
+      - name: Check value
+        run: |
+          if [[ "${{ steps.test.outputs.needs-updating }}" != "true" ]]; then
+            exit 1
+          fi
+
   #####################################
   # Test with multiple platforms
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * Added CI coverage for 32-bit Linux (linux/386), mirroring existing test flow on other platforms. Automated checks now run on this architecture as part of the pipeline, including execution and verification steps.

* Chores
  * Expanded CI workflow configuration to include the new platform while keeping existing jobs unchanged. No modifications to application behavior or features; end users should see no differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->